### PR TITLE
feat: support folders for functions and multiple files/folders for ob…

### DIFF
--- a/load.go
+++ b/load.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"io"
 	"os"
+	"path/filepath"
 
 	"k8s.io/apimachinery/pkg/util/yaml"
 
@@ -80,17 +81,48 @@ func LoadObservedResources(file string) ([]composed.Unstructured, error) {
 	return observed, nil
 }
 
-// LoadYAMLStream from the supplied file. Returns an array of byte arrays, where
-// each byte array is expected to be a YAML manifest.
-func LoadYAMLStream(file string) ([][]byte, error) {
-	f, err := os.Open(file) //nolint:gosec // Intentionally taking this as input.
+// LoadYAMLStream from the supplied file or directory. Returns an array of byte
+// arrays, where each byte array is expected to be a YAML manifest.
+func LoadYAMLStream(fileOrDir string) ([][]byte, error) {
+	var files []string
+	info, err := os.Stat(fileOrDir)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot stat file")
+	}
+	if !info.IsDir() {
+		files = append(files, fileOrDir)
+	} else {
+		files, err = filepath.Glob(filepath.Join(fileOrDir, "*.{yaml,yml}"))
+		if err != nil {
+			return nil, errors.Wrap(err, "cannot glob YAML files")
+		}
+		if len(files) == 0 {
+			return nil, errors.Errorf("no YAML files found in %q (.yaml or .yml)", fileOrDir)
+		}
+	}
+
+	out := make([][]byte, 0)
+	for i := range files {
+		o, err := LoadYAMLStreamFromFile(files[i])
+		if err != nil {
+			return nil, errors.Wrap(err, "cannot load YAML stream from file")
+		}
+		out = append(out, o...)
+	}
+
+	return out, nil
+}
+
+// LoadYAMLStreamFromFile from the supplied file. Returns an array of byte
+// arrays, where each byte array is expected to be a YAML manifest.
+func LoadYAMLStreamFromFile(file string) ([][]byte, error) {
+	out := make([][]byte, 0)
+	f, err := os.Open(file) //nolint:gosec // Taking this input is intentional.
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot open file")
 	}
 	defer f.Close() //nolint:errcheck // Only open for reading.
 	yr := yaml.NewYAMLReader(bufio.NewReader(f))
-
-	out := make([][]byte, 0)
 
 	for {
 		bytes, err := yr.Read()
@@ -105,6 +137,5 @@ func LoadYAMLStream(file string) ([][]byte, error) {
 		}
 		out = append(out, bytes)
 	}
-
 	return out, nil
 }

--- a/main.go
+++ b/main.go
@@ -22,9 +22,9 @@ type CLI struct {
 
 	CompositeResource string `arg:"" type:"existingfile" help:"A YAML manifest containing the Composite Resource (XR) to render."`
 	Composition       string `arg:"" type:"existingfile" help:"A YAML manifest containing the Composition to use. Must be mode: Pipeline."`
-	Functions         string `arg:"" type:"existingfile" help:"A YAML stream of manifests containing the Composition Functions to use."`
+	Functions         string `arg:"" help:"A stream or folder of YAML manifests containing the Composition Functions to use."`
 
-	ObservedResources string `short:"o" type:"existingfile" help:"An optional YAML stream of manifests mocking the observed state of composed resources."`
+	ObservedResources []string `short:"o" help:"An optional stream or directory of YAML manifests mocking the observed state of composed resources."`
 }
 
 // Run xrender.
@@ -51,10 +51,10 @@ func (c *CLI) Run() error { //nolint:gocyclo // Only a touch over.
 	}
 
 	ors := []composed.Unstructured{}
-	if c.ObservedResources != "" {
-		ors, err = LoadObservedResources(c.ObservedResources)
+	for i := range c.ObservedResources {
+		ors, err = LoadObservedResources(c.ObservedResources[i])
 		if err != nil {
-			return errors.Wrapf(err, "cannot load observed composed resources from %q", c.ObservedResources)
+			return errors.Wrapf(err, "cannot load observed composed resources from %q", c.ObservedResources[i])
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ type CLI struct {
 
 	CompositeResource string `arg:"" type:"existingfile" help:"A YAML manifest containing the Composite Resource (XR) to render."`
 	Composition       string `arg:"" type:"existingfile" help:"A YAML manifest containing the Composition to use. Must be mode: Pipeline."`
-	Functions         string `arg:"" help:"A stream or folder of YAML manifests containing the Composition Functions to use."`
+	Functions         string `arg:"" help:"A stream or directory of YAML manifests containing the Composition Functions to use."`
 
 	ObservedResources []string `short:"o" help:"An optional stream or directory of YAML manifests mocking the observed state of composed resources."`
 }


### PR DESCRIPTION
…served resources

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes https://github.com/crossplane-contrib/xrender/issues/2

With this users can pass multiple times the `-o/--observed-resources` flag to specify multiple paths at which we should look for resources, each of which can even be a folder, in which we'll look up for all the files with a `yaml` or `yml` extension.

Also functions now support folders.

```shell
Usage: xrender <composite-resource> <composition> <functions>

Render an XR using Composition Functions.

Arguments:
  <composite-resource>    A YAML manifest containing the Composite Resource (XR) to render.
  <composition>           A YAML manifest containing the Composition to use. Must be mode: Pipeline.
  <functions>             A stream or folder of YAML manifests containing the Composition Functions to use.

Flags:
  -h, --help                                         Show context-sensitive help.
  -d, --debug                                        Emit debug logs in addition to info logs.
      --timeout=3m                                   How long to run before timing out.
  -o, --observed-resources=OBSERVED-RESOURCES,...    An optional stream or directory of YAML manifests mocking the observed state of composed resources.

```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [x] Run `make reviewable` to ensure this PR is ready for review.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
