### PR TITLE
feat: add xrender.crossplane.io/runtime-docker-pull-policy annotation

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -46,7 +46,7 @@ type RuntimeContext struct {
 func GetRuntime(fn pkgv1beta1.Function) (Runtime, error) {
 	switch r := fn.GetAnnotations()[AnnotationKeyRuntime]; r {
 	case AnnotationValueRuntimeDocker, AnnotationValueRuntimeDefault:
-		return GetRuntimeDocker(fn), nil
+		return GetRuntimeDocker(fn)
 	case AnnotationValueRuntimeDevelopment:
 		return GetRuntimeDevelopment(fn), nil
 	default:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Supersedes #9.

Adds an annotation that can be set on Functions to specify whether the image should be pulled Always, IfNotPresent or Never, with the same semantic as Kubernetes' imagePullPolicy.

```yaml
---
apiVersion: pkg.crossplane.io/v1beta1
kind: Function
metadata:
  name: function-dummy
  annotations:
    xrender.crossplane.io/runtime-docker-pull-policy: IfNotPresent
spec:
  package: xpkg.upbound.io/crossplane-contrib/function-dummy:v0.2.1
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [x] Run `make reviewable` to ensure this PR is ready for review.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
