### PR TITLE
Reduce the default timeout to 1m

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 // CLI arguments and flags for xrender.
 type CLI struct {
 	Debug   bool          `short:"d" help:"Emit debug logs in addition to info logs."`
-	Timeout time.Duration `help:"How long to run before timing out." default:"3m"`
+	Timeout time.Duration `help:"How long to run before timing out." default:"1m"`
 
 	CompositeResource string `arg:"" type:"existingfile" help:"A YAML manifest containing the Composite Resource (XR) to render."`
 	Composition       string `arg:"" type:"existingfile" help:"A YAML manifest containing the Composition to use. Must be mode: Pipeline."`


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

This is a bit of a tricky one. We need to balance potentially having enough time to pull a couple of Functions with not making folks wait forever for the context to timeout if something goes wrong (e.g. a Function fails to run and we're waiting for our gRPC call to timeout).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [x] Run `make reviewable` to ensure this PR is ready for review.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
