### PR TITLE
Optionally include Function pipeline results in the output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	google.golang.org/protobuf v1.31.0
 	k8s.io/apimachinery v0.28.2
 	sigs.k8s.io/controller-runtime v0.16.1
-	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -65,4 +64,5 @@ require (
 	k8s.io/utils v0.0.0-20230505201702-9f6742963106 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
+	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ type CLI struct {
 	Functions         string `arg:"" help:"A stream or directory of YAML manifests containing the Composition Functions to use."`
 
 	ObservedResources []string `short:"o" help:"An optional stream or directory of YAML manifests mocking the observed state of composed resources."`
-	IncludeResults    bool     `short:"r" help:"Include Results in the output. Results are emitted as a 'fake' KRM-like object of kind: Result."`
+	IncludeResults    bool     `short:"r" default:"true" help:"Include Results in the output. Results are emitted as a 'fake' KRM-like object of kind: Result."`
 }
 
 // Run xrender.

--- a/main.go
+++ b/main.go
@@ -4,10 +4,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/alecthomas/kong"
-	"sigs.k8s.io/yaml"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/resource/unstructured/composed"
@@ -25,6 +26,7 @@ type CLI struct {
 	Functions         string `arg:"" help:"A stream or directory of YAML manifests containing the Composition Functions to use."`
 
 	ObservedResources []string `short:"o" help:"An optional stream or directory of YAML manifests mocking the observed state of composed resources."`
+	IncludeResults    bool     `short:"r" help:"Include Results in the output. Results are emitted as a 'fake' KRM-like object of kind: Result."`
 }
 
 // Run xrender.
@@ -78,19 +80,28 @@ func (c *CLI) Run() error { //nolint:gocyclo // Only a touch over.
 	// server-side apply would do (e.g. merging vs atomically replacing arrays)
 	// and we don't have enough context (i.e. OpenAPI schemas) to do that.
 
-	y, err := yaml.Marshal(out.CompositeResource.GetUnstructured())
-	if err != nil {
+	s := json.NewSerializerWithOptions(json.DefaultMetaFactory, nil, nil, json.SerializerOptions{Yaml: true})
+
+	fmt.Println("---")
+	if err := s.Encode(out.CompositeResource, os.Stdout); err != nil {
 		return errors.Wrapf(err, "cannot marshal composite resource %q to YAML", xr.GetName())
 	}
-	fmt.Printf("---\n%s", y)
 
-	for _, cd := range out.ComposedResources {
-		y, err := yaml.Marshal(cd.GetUnstructured())
-		if err != nil {
+	for i := range out.ComposedResources {
+		fmt.Println("---")
+		if err := s.Encode(&out.ComposedResources[i], os.Stdout); err != nil {
 			// TODO(negz): Use composed name annotation instead.
-			return errors.Wrapf(err, "cannot marshal composed resource %q to YAML", cd.GetName())
+			return errors.Wrapf(err, "cannot marshal composed resource %q to YAML", out.ComposedResources[i].GetName())
 		}
-		fmt.Printf("---\n%s", y)
+	}
+
+	if c.IncludeResults {
+		for i := range out.Results {
+			fmt.Println("---")
+			if err := s.Encode(&out.Results[i], os.Stdout); err != nil {
+				return errors.Wrap(err, "cannot marshal result to YAML")
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes https://github.com/crossplane-contrib/xrender/issues/6

Crossplane would log these results, and emit them as Kubernetes events. I figured emitting them as a 'fake' type would help make it more obvious where they were coming from.

I tried defining an actual runtime.Object for Result but it serialized a bit ugly, due to including an empty creationTimestamp and missing its type metadata. Emitting it as unstructured seemed easier and prettier.

It looks like this:

```yaml
# $ xrender -r claim.yaml composition.yaml functions.yaml
---
apiVersion: aws.caas.upbound.io/v1alpha1
kind: Cluster
metadata:
  name: aws-spoke-01
---
apiVersion: aws.caas.upbound.io/v1alpha1
kind: XServices
metadata:
  annotations:
    crossplane.io/composition-resource-name: composite-cluster-services
  generateName: aws-spoke-01-
  labels:
    crossplane.io/composite: aws-spoke-01
  ownerReferences:
  - apiVersion: aws.caas.upbound.io/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: Cluster
    name: aws-spoke-01
    uid: ""
spec:
  gitops:
    url: https://github.com/upbound/caas-cluster-configuration
  providerConfigRef:
    name: aws-spoke-01
---
apiVersion: aws.caas.upbound.io/v1alpha1
kind: XNetwork
metadata:
  annotations:
    crossplane.io/composition-resource-name: composite-network-eks
  generateName: aws-spoke-01-
  labels:
    crossplane.io/composite: aws-spoke-01
  ownerReferences:
  - apiVersion: aws.caas.upbound.io/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: Cluster
    name: aws-spoke-01
    uid: ""
spec:
  parameters:
    id: aws-spoke-01
    region: eu-central-1
---
apiVersion: xrender.crossplane.io/v1beta1
kind: Result
message: 'cannot render FromComposite patches for composed resource "composite-cluster-eks":
  cannot apply the "FromCompositeFieldPath" patch at index 12: status: no such field'
severity: SEVERITY_WARNING
step: patch-and-transform
```

I figured it should be behind a flag because you might only want to see "real" Kubernetes objects that you could apply to a cluster (or diff against a cluster) come out when you run `xrender`. I'm not sure about the flag being off by default though.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Added or updated unit **and** E2E tests for my change.~
- [x] Run `make reviewable` to ensure this PR is ready for review.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
