### PR TITLE
Load all observed resources

### DIFF
--- a/load_test.go
+++ b/load_test.go
@@ -116,11 +116,11 @@ func TestLoadComposition(t *testing.T) {
 			xr, err := LoadComposition(tc.file)
 
 			if diff := cmp.Diff(tc.want.comp, xr, test.EquateConditions()); diff != "" {
-				t.Errorf("LoadCompositeResource(..), -want, +got:\n%s", diff)
+				t.Errorf("LoadComposition(..), -want, +got:\n%s", diff)
 			}
 
 			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
-				t.Errorf("LoadCompositeResource(..), -want, +got:\n%s", diff)
+				t.Errorf("LoadComposition(..), -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -192,11 +192,11 @@ func TestLoadFunctions(t *testing.T) {
 			xr, err := LoadFunctions(tc.file)
 
 			if diff := cmp.Diff(tc.want.fns, xr, test.EquateConditions()); diff != "" {
-				t.Errorf("LoadCompositeResource(..), -want, +got:\n%s", diff)
+				t.Errorf("LoadFunctions(..), -want, +got:\n%s", diff)
 			}
 
 			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
-				t.Errorf("LoadCompositeResource(..), -want, +got:\n%s", diff)
+				t.Errorf("LoadFunctions(..), -want, +got:\n%s", diff)
 			}
 		})
 	}
@@ -262,11 +262,11 @@ func TestLoadObservedResources(t *testing.T) {
 			xr, err := LoadObservedResources(tc.file)
 
 			if diff := cmp.Diff(tc.want.ors, xr, test.EquateConditions()); diff != "" {
-				t.Errorf("LoadCompositeResource(..), -want, +got:\n%s", diff)
+				t.Errorf("LoadObservedResources(..), -want, +got:\n%s", diff)
 			}
 
 			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
-				t.Errorf("LoadCompositeResource(..), -want, +got:\n%s", diff)
+				t.Errorf("LoadObservedResources(..), -want, +got:\n%s", diff)
 			}
 		})
 	}

--- a/main.go
+++ b/main.go
@@ -52,10 +52,11 @@ func (c *CLI) Run() error { //nolint:gocyclo // Only a touch over.
 
 	ors := []composed.Unstructured{}
 	for i := range c.ObservedResources {
-		ors, err = LoadObservedResources(c.ObservedResources[i])
+		loaded, err := LoadObservedResources(c.ObservedResources[i])
 		if err != nil {
 			return errors.Wrapf(err, "cannot load observed composed resources from %q", c.ObservedResources[i])
 		}
+		ors = append(ors, loaded...)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)

--- a/testdata/observed.yaml
+++ b/testdata/observed.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: example.org/v1alpha1
+kind: ComposedResource
+metadata:
+  name: test-xrender-a
+  annotations:
+    crossplane.io/composition-resource-name: resource-a
+spec:
+  coolField: "I'm cool!"
+---
+apiVersion: example.org/v1alpha1
+kind: ComposedResource
+metadata:
+  name: test-xrender-b
+  annotations:
+    crossplane.io/composition-resource-name: resource-b
+spec:
+  coolerField: "I'm cooler!"


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

I thought loading observed resources was completely broken, but it's not (there was an issue with my YAML). In my quest to figure this out I added a test, and refactored slightly the code that loads observed resources to support multiple files/directories of observed resources (I think that was the original intent).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
